### PR TITLE
Fix hidden items group logic and Ryken integration bug

### DIFF
--- a/src/main/java/com/balugaq/jeg/api/groups/HiddenItemsGroup.java
+++ b/src/main/java/com/balugaq/jeg/api/groups/HiddenItemsGroup.java
@@ -73,7 +73,7 @@ public class HiddenItemsGroup extends BaseGroup<HiddenItemsGroup> {
         super(key, icon);
         this.page = 1;
         List<SlimefunItem> slimefunItemList = new ArrayList<>();
-        for (SlimefunItem item : Slimefun.getRegistry().getAllSlimefunItems()) {
+        for (SlimefunItem item : new ArrayList<>(Slimefun.getRegistry().getAllSlimefunItems())) {
             if (!item.isDisabled() && item.isHidden()) {
                 slimefunItemList.add(item);
             }

--- a/src/main/java/com/balugaq/jeg/core/integrations/rykenslimefuncustomizer/RykenSlimefunCustomizerIntegrationMain.java
+++ b/src/main/java/com/balugaq/jeg/core/integrations/rykenslimefuncustomizer/RykenSlimefunCustomizerIntegrationMain.java
@@ -87,7 +87,7 @@ public class RykenSlimefunCustomizerIntegrationMain implements Integration {
             return;
         }
 
-        for (SlimefunItem sf : Slimefun.getRegistry().getAllSlimefunItems()) {
+        for (SlimefunItem sf : new ArrayList<>(Slimefun.getRegistry().getAllSlimefunItems())) {
             Class<? extends SlimefunItem> clazz = sf.getClass();
             if (!((classCustomWorkbench != null && clazz == classCustomWorkbench)
                     || (classCustomLinkedRecipeMachine != null && clazz == classCustomLinkedRecipeMachine))) {

--- a/src/main/java/com/balugaq/jeg/implementation/items/JEGGuideGroup.java
+++ b/src/main/java/com/balugaq/jeg/implementation/items/JEGGuideGroup.java
@@ -52,6 +52,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.jspecify.annotations.NullMarked;
 
+import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -156,7 +157,7 @@ public class JEGGuideGroup extends ClassicGuideGroup {
                                 }
 
                                 for (ItemGroup itemGroup :
-                                        Slimefun.getRegistry().getAllItemGroups()) {
+                                        new ArrayList<>(Slimefun.getRegistry().getAllItemGroups())) {
                                     if (itemGroup
                                             .getKey()
                                             .equals(new NamespacedKey(Slimefun.instance(), "basic_machines"))) {


### PR DESCRIPTION
🛠 Fix ConcurrentModificationException in Slimefun Registry Iterations
Summary

This PR fixes a ConcurrentModificationException reported in the stack trace.

Root Cause

The exception was caused by iterating directly over Slimefun registry lists such as:

getAllSlimefunItems()

getAllItemGroups()

These lists may be modified during iteration (e.g., during plugin loading or reloading), which leads to crashes.

Changes Made

To fix this issue, I now create snaps