### PR TITLE
Fix the issue where the BossBar of the SlimeHUD repeats after reloading the JustEnoughGuide.

### DIFF
--- a/src/main/java/com/balugaq/jeg/core/integrations/slimehud/JEGPlayerWAILA.java
+++ b/src/main/java/com/balugaq/jeg/core/integrations/slimehud/JEGPlayerWAILA.java
@@ -377,6 +377,7 @@ public class JEGPlayerWAILA extends PlayerWAILA {
 
     @Override
     public void cancel() {
+        super.cancel();
         setVisible(false);
     }
 }


### PR DESCRIPTION
此处取消时没有call super，导致重载JEG或玩家退出后此处任务也依然在运行

可见表现为每重载一次JEG，bossbar多一条