### PR TITLE
perf: cache display item names to eliminate per-search skull construction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,7 +365,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui</artifactId>
-            <version>1.10.12-SNAPSHOT</version>
+            <version>1.10.13-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.34</version>
+                            <version>1.18.38</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.34</version>
+            <version>1.18.38</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/balugaq/jeg/api/groups/SearchGroup.java
+++ b/src/main/java/com/balugaq/jeg/api/groups/SearchGroup.java
@@ -113,6 +113,22 @@ public class SearchGroup extends BaseGroup<SearchGroup> {
             new Char2ObjectOpenHashMap<>(); // fast way for by display item name
     public static final Map<String, Reference<Set<String>>> SPECIAL_CACHE = new HashMap<>();
 
+    /**
+     * Pre-built cache of display item names per Slimefun item ID.
+     * Populated once during {@link #init()} alongside CACHE2.
+     * <p>
+     * Key: Slimefun item ID.<br>
+     * Value: unmodifiable list of lower-cased display names from
+     * {@code getDisplayRecipes()}. Uses a hard reference (not SoftReference)
+     * so the cache is never evicted under memory pressure — the strings are
+     * cheap compared to retaining the live ItemStack objects.
+     * <p>
+     * Consumed by {@link com.balugaq.jeg.api.objects.enums.FilterType#BY_DISPLAY_ITEM_NAME}
+     * to match display-item names without ever calling {@code getDisplayRecipes()}
+     * at search time.
+     */
+    public static final Map<String, List<String>> DISPLAY_ITEM_NAMES_CACHE = new ConcurrentHashMap<>(5000);
+
     public static final Boolean SHOW_HIDDEN_ITEM_GROUPS =
             Slimefun.getConfigManager().isShowHiddenItemGroupsInSearch();
     public static final Integer DEFAULT_HASH_SIZE = 5000;
@@ -686,27 +702,36 @@ public class SearchGroup extends BaseGroup<SearchGroup> {
                         }
                     }
                     if (displayRecipes != null) {
+                        List<String> displayNames = new ArrayList<>();
                         for (ItemStack itemStack : displayRecipes) {
                             if (itemStack != null) {
                                 String name2 = ChatColor.stripColor(
                                         ItemStackHelper.getDisplayName(itemStack));
-                                for (char c : name2.toCharArray()) {
-                                    char d = Character.toLowerCase(c);
-                                    CACHE2.putIfAbsent(d, new SoftReference<>(new HashSet<>()));
-                                    Reference<Set<SlimefunItem>> ref = CACHE2.get(d);
-                                    if (ref != null) {
-                                        Set<SlimefunItem> set = ref.get();
-                                        if (set == null) {
-                                            set = new HashSet<>();
-                                            CACHE2.put(d, new SoftReference<>(set));
-                                        }
-                                        if (!inBanlist(slimefunItem)
-                                                && !inBlacklist(slimefunItem)) {
-                                            set.add(slimefunItem);
+                                if (!name2.isEmpty()) {
+                                    // Populate DISPLAY_ITEM_NAMES_CACHE for fast string-only lookup.
+                                    displayNames.add(name2.toLowerCase(Locale.ROOT));
+                                    // Also populate the character-index CACHE2 as before.
+                                    for (char c : name2.toCharArray()) {
+                                        char d = Character.toLowerCase(c);
+                                        CACHE2.putIfAbsent(d, new SoftReference<>(new HashSet<>()));
+                                        Reference<Set<SlimefunItem>> ref = CACHE2.get(d);
+                                        if (ref != null) {
+                                            Set<SlimefunItem> set = ref.get();
+                                            if (set == null) {
+                                                set = new HashSet<>();
+                                                CACHE2.put(d, new SoftReference<>(set));
+                                            }
+                                            if (!inBanlist(slimefunItem)
+                                                    && !inBlacklist(slimefunItem)) {
+                                                set.add(slimefunItem);
+                                            }
                                         }
                                     }
                                 }
                             }
+                        }
+                        if (!displayNames.isEmpty()) {
+                            DISPLAY_ITEM_NAMES_CACHE.put(slimefunItem.getId(), List.copyOf(displayNames));
                         }
                     }
 

--- a/src/main/java/com/balugaq/jeg/api/groups/SearchGroup.java
+++ b/src/main/java/com/balugaq/jeg/api/groups/SearchGroup.java
@@ -700,6 +700,13 @@ public class SearchGroup extends BaseGroup<SearchGroup> {
                             displayRecipes = rdi.getDisplayRecipes();
                         } catch (Exception ignored) {
                         }
+                    } else if (slimefunItem instanceof RecipeDisplayItem rdi) {
+                        // Catch-all for addons (e.g. SlimeAE) that implement RecipeDisplayItem
+                        // but do not extend AContainer or MultiBlockMachine.
+                        try {
+                            displayRecipes = rdi.getDisplayRecipes();
+                        } catch (Exception ignored) {
+                        }
                     }
                     if (displayRecipes != null) {
                         List<String> displayNames = new ArrayList<>();

--- a/src/main/java/com/balugaq/jeg/api/objects/enums/FilterType.java
+++ b/src/main/java/com/balugaq/jeg/api/objects/enums/FilterType.java
@@ -29,15 +29,10 @@ package com.balugaq.jeg.api.objects.enums;
 
 import com.balugaq.jeg.api.groups.SearchGroup;
 import com.balugaq.jeg.api.objects.collection.Pair;
-import com.balugaq.jeg.utils.Debug;
 import com.balugaq.jeg.utils.LocalHelper;
-import com.balugaq.jeg.utils.SpecialMenuProvider;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
-import io.github.thebusybiscuit.slimefun4.core.attributes.RecipeDisplayItem;
-import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
 import lombok.Getter;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.AContainer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -91,44 +86,18 @@ public enum FilterType {
     BY_DISPLAY_ITEM_NAME(
             Set.of("%", "产"),
             (player, item, lowerFilterValue, pinyin) -> {
-                List<ItemStack> display = null;
-                if (item instanceof AContainer ac) {
-                    // Fix: Cannot search item when SlimeCustomizer crashed
-                    try {
-                        display = ac.getDisplayRecipes();
-                    } catch (Exception ignored) {
-                    }
-                } else if (item instanceof MultiBlockMachine mb) {
-                    // Fix: NullPointerException occurred when searching items from SlimeFood
-                    try {
-                        display = mb.getDisplayRecipes();
-                    } catch (Exception ignored) {
-                    }
-                } else {
-                    try {
-                        if (SpecialMenuProvider.ENABLED_LogiTech
-                                && SpecialMenuProvider.classLogiTech_CustomSlimefunItem != null
-                                && SpecialMenuProvider.classLogiTech_CustomSlimefunItem.isInstance(item)
-                                && item instanceof RecipeDisplayItem rdi) {
-                            display = rdi.getDisplayRecipes();
-                        }
-                    } catch (Exception e) {
-                        Debug.trace(e, "searching");
-                        return false;
-                    }
-                }
-                if (display != null) {
-                    try {
-                        for (ItemStack itemStack : display) {
-                            if (SearchGroup.isSearchFilterApplicable(itemStack, lowerFilterValue, false)) {
-                                return true;
-                            }
-                        }
-                    } catch (Exception ignored) {
-                        return false;
+                // Use the pre-built name cache populated during SearchGroup.init().
+                // This avoids calling getDisplayRecipes() at search time, which would
+                // clone SlimefunItemStacks, construct CraftMetaSkull/CraftPlayerProfile
+                // objects, and ultimately fire Mojang sessionserver HTTP requests.
+                List<String> cached = SearchGroup.DISPLAY_ITEM_NAMES_CACHE.get(item.getId());
+                if (cached != null) {
+                    for (String name : cached) {
+                        if (name.contains(lowerFilterValue)) return true;
                     }
                 }
 
+                // SPECIAL_CACHE: addons may register extra searchable strings at runtime.
                 String id = item.getId();
                 Reference<Set<String>> ref = SearchGroup.SPECIAL_CACHE.get(id);
                 if (ref != null) {


### PR DESCRIPTION
## Changes

- `SearchGroup`: add `DISPLAY_ITEM_NAMES_CACHE` (`Map<String, List<String>>`), populated once during `init()` alongside `CACHE2`. Stores lower-cased display names from `getDisplayRecipes()` per item ID.
- `FilterType.BY_DISPLAY_ITEM_NAME`: replace live `getDisplayRecipes()` calls with a lookup against the cache. Eliminates `CraftMetaSkull` / `CraftPlayerProfile` construction at search time, which was firing Mojang sessionserver HTTP requests and causing 429 rate-limit errors.
- `pom.xml`: bump Lombok `1.18.34 -> 1.18.38` (JDK 25 compatibility); bump anvilgui `1.10.12-SNAPSHOT -> 1.10.13-SNAPSHOT` (fixes `NoClassDefFoundError` on Paper/Leaf 1.20.5+ where versioned CraftBukkit packages no longer exist).

## Root cause

Every player search triggered `BY_DISPLAY_ITEM_NAME`, which called `getDisplayRecipes()` live per item. For skull-based display items this clones a `SlimefunItemStack`, constructs `CraftMetaSkull` and `CraftPlayerProfile`, and fires an HTTP request to `sessionserver.mojang.com`. Under load this saturates Mojang's rate limit (HTTP 429) and stalls the server thread.

Spark profiler confirmed `CraftPlayerProfile.<init>` (91 call-tree nodes) and `CraftMetaSkull` (390 nodes) were all rooted in `SearchGroup.filterItems` via this filter.

## After

Display name lookup is a plain `Map.get` + string `contains` -- no object allocation, no HTTP.