### PR TITLE
fix: NPE when accessing uninitialised page in BaseGroup.getByPage

### DIFF
--- a/src/main/java/com/balugaq/jeg/api/groups/BaseGroup.java
+++ b/src/main/java/com/balugaq/jeg/api/groups/BaseGroup.java
@@ -92,7 +92,7 @@ public abstract class BaseGroup<T extends BaseGroup<T>> extends FlexItemGroup im
         if (this.pageMap.containsKey(page)) {
             return this.pageMap.get(page);
         } else {
-            synchronized (this.pageMap.get(1)) {
+            synchronized (this.pageMap) {
                 if (this.pageMap.containsKey(page)) {
                     return this.pageMap.get(page);
                 }


### PR DESCRIPTION
`BaseGroup.getByPage()` 在目标 page 未缓存时，使用 `synchronized (this.pageMap.get(1))` 加锁。当 page 1 尚未初始化时，`get(1)` 返回 `null`，导致 `NullPointerException`：

```
[15:41:12 ERROR]: [Slimefun] An exception thrown while handling the click:
java.lang.NullPointerException: Cannot enter synchronized block because the return value of "it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap.get(int)" is null
        at [粘液附属-jeg]JustEnoughGuide v2.1.21.jar//com.balugaq.jeg.api.groups.BaseGroup.getByPage(BaseGroup.java:95) ~[?:?]
        at [粘液附属-jeg]JustEnoughGuide v2.1.21.jar//com.balugaq.jeg.api.groups.MixedGroup.lambda$generateMenu$6(MixedGroup.java:218) ~[?:?]
        at [粘液附属-jeg]JustEnoughGuide v2.1.21.jar//com.balugaq.jeg.utils.EventUtil$EventBuilder.ifSuccess(EventUtil.java:160) ~[?:?]
        at [粘液附属-jeg]JustEnoughGuide v2.1.21.jar//com.balugaq.jeg.api.groups.MixedGroup.lambda$generateMenu$5(MixedGroup.java:216) ~[?:?]
        at [粘液科技]Slimefun-DEV.jar//me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.MenuListener.handleEvent(MenuListener.java:80) ~[?:?]
        at [粘液科技]Slimefun-DEV.jar//me.mrCookieSlime.CSCoreLibPlugin.general.Inventory.MenuListener.onClick(MenuListener.java:55) ~[?:?]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:71) ~[leaf-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:60) ~[leaf-1.21.11.jar:1.21.11-166-2b272d7]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:131) ~[leaf-1.21.11.jar:1.21.11-166-2b272d7]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:629) ~[leaf-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at net.minecraft.server.network.ServerGamePacketListenerImpl.handleContainerClick(ServerGamePacketListenerImpl.java:3430) ~[leaf-1.21.11.jar:1.21.11-166-2b272d
7]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:59) ~[leaf-1.21.11.jar:1.21.11-166-2b272d7]
        at net.minecraft.network.protocol.game.ServerboundContainerClickPacket.handle(ServerboundContainerClickPacket.java:14) ~[leaf-1.21.11.jar:1.21.11-166-2b272d7]
        at net.minecraft.network.PacketProcessor$ListenerAndPacket.handle(PacketProcessor.java:99) ~[leaf-1.21.11.jar:1.21.11-166-2b272d7]
        at net.minecraft.network.PacketProcessor.executeSinglePacket(PacketProcessor.java:33) ~[leaf-1.21.11.jar:1.21.11-166-2b272d7]
        at net.minecraft.server.MinecraftServer.pollTask(MinecraftServer.java:1601) ~[leaf-1.21.11.jar:1.21.11-166-2b272d7]
        at net.minecraft.server.MinecraftServer.recordTaskExecutionTimeWhileWaiting(MinecraftServer.java:1297) ~[leaf-1.21.11.jar:1.21.11-166-2b272d7]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1441) ~[leaf-1.21.11.jar:1.21.11-166-2b272d7]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:430) ~[leaf-1.21.11.jar:1.21.11-166-2b272d7]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
```

本PR将锁对象从 `this.pageMap.get(1)` 改为 `this.pageMap`，保证锁始终非 null 的同时保持原有的 double-check locking 语义，锁粒度不变