### PR TITLE
支持 tiers.yml 修改后 reload 生效与自定义分类名

### DIFF
--- a/src/main/java/com/balugaq/jeg/api/editor/GroupResorter.java
+++ b/src/main/java/com/balugaq/jeg/api/editor/GroupResorter.java
@@ -24,9 +24,11 @@ import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.NestedItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.SubItemGroup;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.common.ChatColors;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Range;
@@ -40,6 +42,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author balugaq
@@ -56,6 +60,9 @@ public class GroupResorter {
     public static @Nullable FileConfiguration config = null;
 
     public static void load() {
+        // Re-read tiers.yml from disk so manual edits take effect on reload
+        // instead of being overwritten by the stale in-memory cache.
+        config = tiersFile.exists() ? YamlConfiguration.loadConfiguration(tiersFile) : null;
         loadInternal();
     }
 
@@ -63,13 +70,15 @@ public class GroupResorter {
     @CallTimeSensitive(CallTimeSensitive.AfterSlimefunLoaded)
     private static void loadInternal() {
         JustEnoughGuide.runLater(() -> {
-            if (!hasCfg()) {
+            if (!tiersFile.exists()) {
                 int i = 0;
                 for (ItemGroup itemGroup :
                     new ArrayList<>(Slimefun.getRegistry().getAllItemGroups())) {
                     setTier(itemGroup, i++);
                     setNameCfg(getKey(itemGroup), getDisplayName(itemGroup));
+                    setCustomNameCfg(getKey(itemGroup), false);
                 }
+                saveCfg();
                 return;
             }
             int offset = 0;
@@ -77,7 +86,8 @@ public class GroupResorter {
             for (ItemGroup itemGroup : new ArrayList<>(Slimefun.getRegistry().getAllItemGroups())) {
                 oldTiers.put(itemGroup, itemGroup.getTier());
 
-                Integer cfg = getTierCfg(getKey(itemGroup));
+                String key = getKey(itemGroup);
+                Integer cfg = getTierCfg(key);
                 if (cfg != null) {
                     setTier(itemGroup, cfg + offset);
                 } else {
@@ -85,15 +95,21 @@ public class GroupResorter {
                         // New ItemGroup
                         // Sort by related order.
                         setTier(itemGroup, getTier(lastItemGroup) + 1);
-                        setNameCfg(getKey(itemGroup), getDisplayName(itemGroup));
+                        setCustomNameCfg(key, false);
                         offset += 1;
                     } else {
                         // By default
                         setTier(itemGroup, itemGroup.getTier());
                     }
                 }
+                // name is plugin-managed by default (customname: false),
+                // so keep it in sync with the real display name unless the user opted in.
+                if (!isCustomNameEnabled(key)) {
+                    setNameCfg(key, getDisplayName(itemGroup));
+                }
                 lastItemGroup = itemGroup;
             }
+            saveCfg();
         }, 1L);
     }
 
@@ -133,8 +149,60 @@ public class GroupResorter {
         getOrCreateConfig().set(key + ".name", name);
     }
 
+    public static void setCustomNameCfg(final String key, final boolean enabled) {
+        getOrCreateConfig().set(key + ".customname", enabled);
+    }
+
+    public static boolean isCustomNameEnabled(final String key) {
+        return getOrCreateConfig().getBoolean(key + ".customname", false);
+    }
+
     public static String getDisplayName(final ItemGroup itemGroup) {
         return itemGroup.getUnlocalizedName();
+    }
+
+    /**
+     * Matches hex color codes like {@code &#FFAA00} or {@code #FFAA00}.
+     */
+    private static final Pattern HEX_COLOR_PATTERN = Pattern.compile("(?:&|§)?#([0-9a-fA-F]{6})");
+
+    /**
+     * Converts hex color codes ({@code &#RRGGBB} / {@code #RRGGBB}) into the legacy
+     * {@code &x&R&R&G&G&B&B} format so {@link ChatColors#color(String)} can render them.
+     */
+    private static String translateHexColors(String input) {
+        if (!input.contains("#")) {
+            return input;
+        }
+        Matcher matcher = HEX_COLOR_PATTERN.matcher(input);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            StringBuilder replacement = new StringBuilder("&x");
+            for (char c : matcher.group(1).toLowerCase().toCharArray()) {
+                replacement.append('&').append(c);
+            }
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement.toString()));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Applies the custom name configured in tiers.yml to the given item stack.
+     * Only applied when the item group's {@code customname} flag is set to true,
+     * otherwise the original stack is returned untouched.
+     */
+    public static ItemStack applyName(final ItemGroup itemGroup, final ItemStack item) {
+        if (!isCustomNameEnabled(getKey(itemGroup))) {
+            return item;
+        }
+        final String name = getNameCfg(getKey(itemGroup));
+        if (name == null) {
+            return item;
+        }
+        final ItemStack copy = item.clone();
+        copy.editMeta(meta -> meta.setDisplayName(ChatColors.color(translateHexColors(name))));
+        return copy;
     }
 
     public static FileConfiguration getOrCreateConfig() {

--- a/src/main/java/com/balugaq/jeg/api/editor/GroupResorter.java
+++ b/src/main/java/com/balugaq/jeg/api/editor/GroupResorter.java
@@ -20,11 +20,11 @@ package com.balugaq.jeg.api.editor;
 import com.balugaq.jeg.api.objects.annotations.CallTimeSensitive;
 import com.balugaq.jeg.implementation.JustEnoughGuide;
 import com.balugaq.jeg.utils.Debug;
+import com.balugaq.jeg.utils.StringUtil;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.NestedItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.SubItemGroup;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
-import io.github.thebusybiscuit.slimefun4.libraries.dough.common.ChatColors;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
@@ -42,8 +42,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * @author balugaq
@@ -102,7 +100,7 @@ public class GroupResorter {
                         setTier(itemGroup, itemGroup.getTier());
                     }
                 }
-                // name is plugin-managed by default (customname: false),
+                // name is plugin-managed by default (custom_name: false),
                 // so keep it in sync with the real display name unless the user opted in.
                 if (!isCustomNameEnabled(key)) {
                     setNameCfg(key, getDisplayName(itemGroup));
@@ -150,11 +148,11 @@ public class GroupResorter {
     }
 
     public static void setCustomNameCfg(final String key, final boolean enabled) {
-        getOrCreateConfig().set(key + ".customname", enabled);
+        getOrCreateConfig().set(key + ".custom_name", enabled);
     }
 
     public static boolean isCustomNameEnabled(final String key) {
-        return getOrCreateConfig().getBoolean(key + ".customname", false);
+        return getOrCreateConfig().getBoolean(key + ".custom_name", false);
     }
 
     public static String getDisplayName(final ItemGroup itemGroup) {
@@ -162,34 +160,8 @@ public class GroupResorter {
     }
 
     /**
-     * Matches hex color codes like {@code &#FFAA00} or {@code #FFAA00}.
-     */
-    private static final Pattern HEX_COLOR_PATTERN = Pattern.compile("(?:&|§)?#([0-9a-fA-F]{6})");
-
-    /**
-     * Converts hex color codes ({@code &#RRGGBB} / {@code #RRGGBB}) into the legacy
-     * {@code &x&R&R&G&G&B&B} format so {@link ChatColors#color(String)} can render them.
-     */
-    private static String translateHexColors(String input) {
-        if (!input.contains("#")) {
-            return input;
-        }
-        Matcher matcher = HEX_COLOR_PATTERN.matcher(input);
-        StringBuilder sb = new StringBuilder();
-        while (matcher.find()) {
-            StringBuilder replacement = new StringBuilder("&x");
-            for (char c : matcher.group(1).toLowerCase().toCharArray()) {
-                replacement.append('&').append(c);
-            }
-            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement.toString()));
-        }
-        matcher.appendTail(sb);
-        return sb.toString();
-    }
-
-    /**
      * Applies the custom name configured in tiers.yml to the given item stack.
-     * Only applied when the item group's {@code customname} flag is set to true,
+     * Only applied when the item group's {@code custom_name} flag is set to true,
      * otherwise the original stack is returned untouched.
      */
     public static ItemStack applyName(final ItemGroup itemGroup, final ItemStack item) {
@@ -201,7 +173,7 @@ public class GroupResorter {
             return item;
         }
         final ItemStack copy = item.clone();
-        copy.editMeta(meta -> meta.setDisplayName(ChatColors.color(translateHexColors(name))));
+        copy.editMeta(meta -> meta.setDisplayName(StringUtil.translateHexColors(name)));
         return copy;
     }
 

--- a/src/main/java/com/balugaq/jeg/utils/GuideUtil.java
+++ b/src/main/java/com/balugaq/jeg/utils/GuideUtil.java
@@ -416,6 +416,22 @@ public final class GuideUtil {
         return BOOK_MARK_MENU_BUTTON;
     }
 
+    /**
+     * Builds the display icon for an item group, applying the JEG patch chain and
+     * the custom name configured in tiers.yml.
+     */
+    public static ItemStack getItemGroupDisplayIcon(Player player, ItemGroup itemGroup) {
+        return getItemGroupDisplayIcon(player, itemGroup, itemGroup.getItem(player));
+    }
+
+    /**
+     * Builds the display icon for an item group based on the given icon,
+     * applying the JEG patch chain and the custom name configured in tiers.yml.
+     */
+    public static ItemStack getItemGroupDisplayIcon(Player player, ItemGroup itemGroup, ItemStack icon) {
+        return GroupResorter.applyName(itemGroup, PatchScope.ItemGroup.patch(player, icon));
+    }
+
     @SuppressWarnings("deprecation")
     public static void addItemMarkButton(
         ChestMenu menu,

--- a/src/main/java/com/balugaq/jeg/utils/StringUtil.java
+++ b/src/main/java/com/balugaq/jeg/utils/StringUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024-2026 balugaq
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package com.balugaq.jeg.utils;
+
+import io.github.thebusybiscuit.slimefun4.libraries.dough.common.ChatColors;
+import lombok.experimental.UtilityClass;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author balugaq
+ * @since 2.1
+ */
+@UtilityClass
+@NullMarked
+public class StringUtil {
+    /**
+     * Matches hex color codes like {@code &#FFAA00} or {@code #FFAA00}.
+     */
+    private static final Pattern HEX_COLOR_PATTERN = Pattern.compile("(?:&|§)?#([0-9a-fA-F]{6})");
+
+    /**
+     * Converts hex color codes ({@code &#RRGGBB} / {@code #RRGGBB}) into the legacy
+     * {@code &x&R&R&G&G&B&B} format and immediately applies all color codes via
+     * {@link ChatColors#color(String)} in a single step.
+     */
+    public String translateHexColors(String input) {
+        if (!input.contains("#")) {
+            return ChatColors.color(input);
+        }
+        Matcher matcher = HEX_COLOR_PATTERN.matcher(input);
+        StringBuilder sb = new StringBuilder();
+        while (matcher.find()) {
+            StringBuilder replacement = new StringBuilder("&x");
+            for (char c : matcher.group(1).toLowerCase().toCharArray()) {
+                replacement.append('&').append(c);
+            }
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement.toString()));
+        }
+        matcher.appendTail(sb);
+        return ChatColors.color(sb.toString());
+    }
+}

--- a/src/main/java/com/balugaq/jeg/utils/StringUtil.java
+++ b/src/main/java/com/balugaq/jeg/utils/StringUtil.java
@@ -25,7 +25,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * @author balugaq
+ * @author mc506lw
  * @since 2.1
  */
 @UtilityClass

--- a/src/main/java/com/balugaq/jeg/utils/clickhandler/OnDisplay.java
+++ b/src/main/java/com/balugaq/jeg/utils/clickhandler/OnDisplay.java
@@ -18,6 +18,7 @@
 package com.balugaq.jeg.utils.clickhandler;
 
 import city.norain.slimefun4.VaultIntegration;
+import com.balugaq.jeg.api.editor.GroupResorter;
 import com.balugaq.jeg.api.interfaces.CustomIconDisplay;
 import com.balugaq.jeg.api.interfaces.JEGSlimefunGuideImplementation;
 import com.balugaq.jeg.api.interfaces.VanillaItemShade;
@@ -160,7 +161,10 @@ public interface OnDisplay {
             @Override
             public void at(ChestMenu menu, int slot, int page) {
                 menu.addItem(
-                    slot, PatchScope.ItemGroup.patch(player, itemGroup.getItem(player)),
+                    slot, GroupResorter.applyName(
+                        itemGroup,
+                        PatchScope.ItemGroup.patch(player, itemGroup.getItem(player))
+                    ),
                     OnClick.ItemGroup.Normal.create(guide, menu, itemGroup)
                 );
             }
@@ -206,7 +210,10 @@ public interface OnDisplay {
                 });
 
                 menu.addItem(
-                    slot, PatchScope.ItemGroup.patch(player, icon), OnClick.ItemGroup.Bookmark.create(
+                    slot, GroupResorter.applyName(
+                        itemGroup,
+                        PatchScope.ItemGroup.patch(player, icon)
+                    ), OnClick.ItemGroup.Bookmark.create(
                         guide,
                         menu,
                         itemGroup

--- a/src/main/java/com/balugaq/jeg/utils/clickhandler/OnDisplay.java
+++ b/src/main/java/com/balugaq/jeg/utils/clickhandler/OnDisplay.java
@@ -18,7 +18,6 @@
 package com.balugaq.jeg.utils.clickhandler;
 
 import city.norain.slimefun4.VaultIntegration;
-import com.balugaq.jeg.api.editor.GroupResorter;
 import com.balugaq.jeg.api.interfaces.CustomIconDisplay;
 import com.balugaq.jeg.api.interfaces.JEGSlimefunGuideImplementation;
 import com.balugaq.jeg.api.interfaces.VanillaItemShade;
@@ -161,10 +160,7 @@ public interface OnDisplay {
             @Override
             public void at(ChestMenu menu, int slot, int page) {
                 menu.addItem(
-                    slot, GroupResorter.applyName(
-                        itemGroup,
-                        PatchScope.ItemGroup.patch(player, itemGroup.getItem(player))
-                    ),
+                    slot, GuideUtil.getItemGroupDisplayIcon(player, itemGroup),
                     OnClick.ItemGroup.Normal.create(guide, menu, itemGroup)
                 );
             }
@@ -210,10 +206,8 @@ public interface OnDisplay {
                 });
 
                 menu.addItem(
-                    slot, GroupResorter.applyName(
-                        itemGroup,
-                        PatchScope.ItemGroup.patch(player, icon)
-                    ), OnClick.ItemGroup.Bookmark.create(
+                    slot, GuideUtil.getItemGroupDisplayIcon(player, itemGroup, icon),
+                    OnClick.ItemGroup.Bookmark.create(
                         guide,
                         menu,
                         itemGroup

--- a/src/main/resources/tiers.yml
+++ b/src/main/resources/tiers.yml
@@ -1,14 +1,22 @@
 ####################################################
 # group_id:                                        #
 #   nested:                                        #
+#     customname: false                            #
 #     name: "abab"                                 #
 #     tier: 1                                      #
 #   sub:                                           #
 #     group_id2:                                   #
+#       customname: false                          #
 #       name: "abab2"                              #
 #       tier: 2                                    #
 #     group_id3:                                   #
+#       customname: false                          #
 #       name: "abab3"                              #
 #       tier: 3                                    #
+#                                                  #
+# name 必须用双引号包裹，否则颜色代码会导致 YAML 解析失败。#
+# 支持：                                            #
+#   & 颜色代码，如 "&a绿色名字"                        #
+#   HEX 颜色，如 "&#FFAA00橙色名字" / "#FFAA00"       #
 ####################################################
 

--- a/src/main/resources/tiers.yml
+++ b/src/main/resources/tiers.yml
@@ -1,16 +1,16 @@
 ####################################################
 # group_id:                                        #
 #   nested:                                        #
-#     customname: false                            #
+#     custom_name: false                           #
 #     name: "abab"                                 #
 #     tier: 1                                      #
 #   sub:                                           #
 #     group_id2:                                   #
-#       customname: false                          #
+#       custom_name: false                         #
 #       name: "abab2"                              #
 #       tier: 2                                    #
 #     group_id3:                                   #
-#       customname: false                          #
+#       custom_name: false                         #
 #       name: "abab3"                              #
 #       tier: 3                                    #
 #                                                  #


### PR DESCRIPTION
支持直接修改 tiers.yml 后 /jeg reload 生效，并新增自定义分类显示名功能。

- load/reload 时重新从磁盘读取 tiers.yml，不再使用内存旧缓存
- 仅首次启动时自动生成 tiers（判断文件是否存在，而非 config 是否为 null）
- 支持分类设置 customname: true 接管 name 字段，作用于指南分类图标与书签，并支持 HEX 颜色代码（ &#RRGGBB / #RRGGBB ）